### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build Docker, Run IP Sentinel, the Flask IP Blocklist Checker
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/MDHMatt/IP-Sentinel/security/code-scanning/2](https://github.com/MDHMatt/IP-Sentinel/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will apply to all jobs in the workflow unless overridden by a job-specific `permissions` block. Based on the tasks performed in the workflow (e.g., checking out code, building Docker images, and pushing them to DockerHub), the workflow only requires `contents: read` permissions to access the repository's code. No write permissions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
